### PR TITLE
Copy the input slice in `helper.SliceStringRemove()`

### DIFF
--- a/helper/Slices.go
+++ b/helper/Slices.go
@@ -5,7 +5,7 @@ import "slices"
 // SliceStringRemove removes all occurrences of the given value from a slice of
 // strings
 func SliceStringRemove(value string, slice []string) []string {
-	return slices.DeleteFunc(slice, func(s string) bool {
+	return slices.DeleteFunc(slices.Clone(slice), func(s string) bool {
 		return s == value
 	})
 }

--- a/helper/Slices_test.go
+++ b/helper/Slices_test.go
@@ -76,6 +76,21 @@ func TestSliceStringRemove(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("do not motify input slice", func(t *testing.T) {
+		slc := []string{"bar", "foo", "baz"}
+		got := SliceStringRemove("foo", slc)
+		want := []string{"bar", "baz"}
+
+		if !internal.AssertStringSliceEqual(t, want, got) {
+			t.Errorf("SliceStringRemove() = %v, want %v", got, want)
+		}
+
+		if !internal.AssertStringSliceEqual(t, []string{"bar", "foo", "baz"}, slc) {
+			t.Errorf("SliceStringRemove() = %v, want %v", slc, []string{"bar", "foo", "baz"})
+		}
+	})
+
 }
 
 func TestSliceStringUnique(t *testing.T) {


### PR DESCRIPTION
The previous version did, while returning a separate slice as output, also modify the original input slice. Deleting an element there then led to empty strings in the "unload --all" loop, when the loop slice `args` was implicitly modified.
This, in the end, lead to errors on `unload --all` when attempting to delete profiles named `""`.

e.g.:

```
$ env-manager unload --all
Unloading all profiles: awsMain,tfMysqlShared80Dev,allProxy,tfMysqlAuthDev

args: []string{"awsMain", "tfMysqlShared80Dev", "allProxy", "tfMysqlAuthDev"}

Unloading profile: awsMain
args: []string{"tfMysqlShared80Dev", "allProxy", "tfMysqlAuthDev", ""}

Unloading profile: allProxy
args: []string{"tfMysqlShared80Dev", "tfMysqlAuthDev", "", ""}

Unloading profile: 
Error: profile name cannot be empty
```



Solved by copying the input slice.